### PR TITLE
Add Enforce for Git signing policy

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -1,0 +1,14 @@
+# Copyright 2023 Chainguard, Inc
+# SPDX-License-Identifier: Apache-2.0
+spec:
+  authorities:
+  - keyless:
+      url: https://fulcio.sigstore.dev
+      identities:
+      - subjectRegExp: .+@chainguard.dev$
+        issuer: https://accounts.google.com
+    ctlog:
+      url: https://rekor.sigstore.dev
+  - key:
+      # Allow commits signed by Github (merge commits)
+      kms: https://github.com/web-flow.gpg


### PR DESCRIPTION
Our commit signing workflow always fails on main because merge commits are signed by Github GPG key. 

Example:

![image](https://user-images.githubusercontent.com/12156185/225755349-9e651426-af73-4fbd-8272-e39684d29524.png)

This adds a policy to allow gitsigned commits from `.+@chainguard.dev` folks and the Github gpg webflow key.