### PR TITLE
Fix: use helm conditional on value that had go templating

### DIFF
--- a/charts/enforce-agent/Chart.yaml
+++ b/charts/enforce-agent/Chart.yaml
@@ -8,7 +8,7 @@ description: |
 
   Documentation for the chart can be found [here](https://edu.chainguard.dev/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/alternative-installation-methods/).
 type: application
-version: 0.0.27
+version: 0.0.28
 appVersion: v.0.1.100
 keywords:
   - chainguard

--- a/charts/enforce-agent/templates/enforce-agent.yaml
+++ b/charts/enforce-agent/templates/enforce-agent.yaml
@@ -890,7 +890,7 @@ webhooks:
         name: webhook
         # This is where the MCP will host this webhook (see Webhook below)
         path: /admissionwebhooks/cosigned-policy-defaulting
-{{- if .Values.enforcerOptions.webhookFailOpen }}        
+{{- if .Values.enforcerOptions.webhookFailOpen }}
     failurePolicy: Ignore
 {{- else }}
     failurePolicy: Fail
@@ -1016,7 +1016,7 @@ webhooks:
     namespaceSelector:
       # The webhook should only apply to things that opt-in
       matchExpressions:
-{{- if eq .Values.enforcerOptions.namespaceEnforcementMode "opt-out" }}      
+{{- if eq .Values.enforcerOptions.namespaceEnforcementMode "opt-out" }}
         - key: policy.sigstore.dev/exclude
           operator: NotIn
 {{- else }}
@@ -1044,11 +1044,7 @@ webhooks:
         name: webhook
         # This is where the MCP will host this webhook (see Webhook below)
         path: /admissionwebhooks/cosigned-resolution
-{{- if .Values.enforcerOptions.webhookFailOpen }}
-    failurePolicy: Ignore
-{{- else }}
     failurePolicy: Fail
-{{- end }}
     reinvocationPolicy: IfNeeded
     sideEffects: None
     timeoutSeconds: 25
@@ -1090,7 +1086,7 @@ webhooks:
     namespaceSelector:
       # The webhook should only apply to things that opt-in
       matchExpressions:
-{{- if eq .Values.enforcerOptions.namespaceEnforcementMode "opt-out" }}      
+{{- if eq .Values.enforcerOptions.namespaceEnforcementMode "opt-out" }}
         - key: policy.sigstore.dev/exclude
           operator: NotIn
 {{- else }}
@@ -1118,7 +1114,11 @@ webhooks:
         name: webhook
         # This is where the MCP will host this webhook (see Webhook below)
         path: /admissionwebhooks/cosigned-verification
+{{- if .Values.enforcerOptions.webhookFailOpen }}
+    failurePolicy: Ignore
+{{- else }}
     failurePolicy: Fail
+{{- end }}
     sideEffects: None
     timeoutSeconds: 25
 ---


### PR DESCRIPTION
The go templating for failurePolicy should be on the `ValidatingWebhookConfiguration` ` enforcer.chainguard.dev`

https://github.com/chainguard-dev/mono/blob/c5ed4364a5c316cde7fe56eec3af2074c49b8388/sigstore/cosign/config/tenant/verification.yaml#L37

and not `MutatingWebhookConfiguration` `enforcer.chainguard.dev`

https://github.com/chainguard-dev/mono/blob/c5ed4364a5c316cde7fe56eec3af2074c49b8388/sigstore/cosign/config/tenant/resolution.yaml#L37

or is it missing the templating in mono for `MutatingWebhookConfiguration` `enforcer.chainguard.dev`