### PR TITLE
Add support for specifying no-match-policy in config-policy-controller

### DIFF
--- a/charts/enforce-agent/Chart.yaml
+++ b/charts/enforce-agent/Chart.yaml
@@ -8,7 +8,7 @@ description: |
 
   Documentation for the chart can be found [here](https://edu.chainguard.dev/chainguard/chainguard-enforce/chainguard-enforce-kubernetes/alternative-installation-methods/).
 type: application
-version: 0.0.63
+version: 0.0.64
 appVersion: v0.1.164
 keywords:
   - chainguard

--- a/charts/enforce-agent/templates/enforce-agent.yaml
+++ b/charts/enforce-agent/templates/enforce-agent.yaml
@@ -982,10 +982,11 @@ kind: ConfigMap
 metadata:
   name: config-policy-controller
   namespace: cosign-system
-{{- if .Values.enforcerOptions.enableCIPCache }}
 data:
+{{- if .Values.enforcerOptions.enableCIPCache }}
   dev.chainguard.enable-cip-cache: "true"
 {{- end }}
+  no-match-policy: {{.Values.enforcerOptions.noMatchPolicy}}
 # Copyright 2022 Chainguard, Inc.
 # SPDX-License-Identifier: Apache-2.0
 ---

--- a/charts/enforce-agent/values.schema.json
+++ b/charts/enforce-agent/values.schema.json
@@ -37,6 +37,9 @@
                 },
                 "webhookFailOpen": {
                     "type": "boolean"
+                },
+                "noMatchPolicy": {
+                    "type": "string"
                 }
             }
         },

--- a/charts/enforce-agent/values.yaml
+++ b/charts/enforce-agent/values.yaml
@@ -22,3 +22,6 @@ enforcerOptions:
   webhookFailOpen: false
   enableCIPCache: false
   namespaceEnforcementMode: "opt-in"
+  # NoMatchPolicy specifies the behavior when a base image doesn't match any
+  # of the listed policies.  It allows the values: allow, deny (default), and warn.
+  noMatchPolicy: "deny"


### PR DESCRIPTION
Allow setting no-match-policy in the config-policy-controller. The default value seems to be "deny" for this based on the code: 

https://github.com/sigstore/policy-controller/blob/3c302d6485f286a1560a13c953c33ce4445c7019/cmd/tester/main.go#L86

Fixes https://github.com/chainguard-dev/customer-issues/issues/547