### PR TITLE
add octo-sts to mono to be able to open pull requests

### DIFF
--- a/.github/chainguard/mono.sts.yaml
+++ b/.github/chainguard/mono.sts.yaml
@@ -1,0 +1,10 @@
+# Allow release tags from our mono repo running the release-helm-charts
+# workflow to push and create a PR to the helm-charts repo to publish the helm charts.
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:chainguard-dev/mono:ref:refs/tags/v.*
+claim_pattern:
+  job_workflow_ref: chainguard-dev/mono/.github/workflows/release-helm-charts.yaml@.*
+
+permissions:
+  contents: write
+  pull-requests: write


### PR DESCRIPTION
not sure if the subject is the correct one as the job is a workflow run https://github.com/chainguard-dev/mono/blob/main/.github/workflows/release-helm-charts.yaml#L9

https://github.com/chainguard-dev/mono/actions/workflows/release-helm-charts.yaml