### PR TITLE
update trust policy to allow mono release to update helm chart

### DIFF
--- a/.github/chainguard/mono.sts.yaml
+++ b/.github/chainguard/mono.sts.yaml
@@ -1,7 +1,7 @@
 # Allow release tags from our mono repo running the release-helm-charts
 # workflow to push and create a PR to the helm-charts repo to publish the helm charts.
 issuer: https://token.actions.githubusercontent.com
-subject_pattern: repo:chainguard-dev/mono:ref:refs/tags/v.*
+subject_pattern: repo:chainguard-dev/mono:ref:refs/(tags/v.*|heads/main)
 claim_pattern:
   job_workflow_ref: chainguard-dev/mono/.github/workflows/release-helm-charts.yaml@.*
 


### PR DESCRIPTION
Workflow to open a PR to update helm chart after mono release failed due to subject mismatch:

https://github.com/chainguard-dev/mono/actions/runs/7716076268/job/21032064596#step:3:9

```
Error: trust policy: subject_pattern "repo:chainguard-dev/mono:ref:refs/heads/main" did not match "repo:chainguard-dev/mono:ref:refs/tags/v.*"
```

Update the `subject_pattern` in the mono trust policy to allow this workflow to complete.